### PR TITLE
Makefile variable name updates & conditional setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@
 
 ####### Compiler, tools and options
 
-CC            = gcc
-FLAGS         = -m64 -pipe -O3 -Wall -W -D_REENTRANT
-LINK          = gcc
-LFLAGS        = -m64 -Wl,-O3
-LIBS          = -lhidapi-libusb
-DEL_FILE      = rm -f
+CC            ?= gcc
+CFLAGS        ?= -m64 -pipe -O3 -Wall -W -D_REENTRANT
+LINK          ?= gcc
+LDFLAGS       ?= -m64 -Wl,-O3
+LDLIBS        ?= -lhidapi-libusb
+RM            ?= rm -f
 
 
 ####### Files
@@ -27,13 +27,13 @@ INSTALLPREFIX = /usr/local/bin
 all: Makefile $(TARGET)
 
 $(TARGET): $(OBJECTS)
-	$(LINK) $(LFLAGS) -o $(TARGET) $(OBJECTS) $(LIBS)
+	$(LINK) $(LDFLAGS) -o $(TARGET) $(OBJECTS) $(LDLIBS)
 
 clean:
-	-$(DEL_FILE) $(OBJECTS)
+	-$(RM) $(OBJECTS)
 
 delete: clean
-	-$(DEL_FILE) $(TARGET)
+	-$(RM) $(TARGET)
 
 install:
 	@mv -v $(TARGET) $(INSTALLPREFIX)/$(TARGET)
@@ -42,4 +42,4 @@ install:
 ####### Compile
 
 main.o: main.c
-	$(CC) -c $(FLAGS) -o main.o main.c
+	$(CC) -c $(CFLAGS) -o main.o main.c


### PR DESCRIPTION
See https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html
Why? On Arch Linux this allows the package building tools to define certain
`LDFLAGS`, which e.g. currently ["harden the data section of an ELF
binary/process"](https://wiki.archlinux.org/index.php/Security_package_guidelines#RELRO) - in practice this means that when building a package and
checking it with expected tools this avoids warnings about potential security
issues.

## Testing
commands before this change:
```
$ make
gcc -c -m64 -pipe -O3 -Wall -W -D_REENTRANT -o main.o main.c
gcc -m64 -Wl,-O3 -o apex-macros main.o -lhidapi-libusb
```
After this change (on my system):
```
$ make
cc -c -m64 -pipe -O3 -Wall -W -D_REENTRANT -o main.o main.c
gcc -m64 -Wl,-O3 -o apex-macros main.o -lhidapi-libusb
$ make delete
...
$ make -R  # no implicit variables
gcc -c -m64 -pipe -O3 -Wall -W -D_REENTRANT -o main.o main.c
gcc -m64 -Wl,-O3 -o apex-macros main.o -lhidapi-libusb
```

If building a package (this requires a `PKGBUILD` file which I've currently not published - I'm still trying to figure out how to deal with the autostart thing):
```
$ makepkg
...
==> Starting build()...
gcc -c -m64 -pipe -O3 -Wall -W -D_REENTRANT -o main.o main.c
gcc -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -o apex-macros main.o -lhidapi-libusb
==> Entering fakeroot environment...
==> Starting package()...
...
```

## Analysis of test results
I realise that this is a subtle difference in behaviour. I think it's still worth it, because:

1. On my system this makes no functional difference, as `cc` is symlinked to `gcc`:
```
$ ls -l /usr/bin/cc
lrwxrwxrwx 1 root root 3 Feb  5 13:29 /usr/bin/cc -> gcc
```
2. It's possible that in some edge cases this may matter. In some using `$CC` as per the platforms wishes may be better (Solaris in some configurations), in some cases perhaps not (Solaris in some other configurations) - see this [SO answer](https://stackoverflow.com/a/1516658/1298153) for details. I think on balance this should solve more issues in practice than it causes, and even if it causes an issue in certain configurations, then it's (after this change) easily fixable with an environment variable override. If not, it could theoretically be worked around based on what's discussed in [this SO answer, which looks at identifying the origin of a variable and changing it based on that](https://stackoverflow.com/a/42958970/1298153), but I don't think the complexity is really worth it.