### PR TITLE
Refactor rules generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,13 @@ INSTALLPREFIX ?= /usr/local/bin
 SOURCES       = main.c
 OBJECTS       = main.o
 TARGET        = apex-macros
+RULESFILE     = 90-apex.rules
 
 ####### Build rules
 
 .PHONY: clean delete install
 
-all: Makefile $(TARGET)
+all: Makefile $(TARGET) $(RULESFILE)
 
 $(TARGET): $(OBJECTS)
 	$(LINK) $(LDFLAGS) -o $(TARGET) $(OBJECTS) $(LDLIBS)
@@ -31,13 +32,16 @@ clean:
 	-$(RM) $(OBJECTS)
 
 delete: clean
-	-$(RM) $(TARGET)
+	-$(RM) $(TARGET) $(RULESFILE)
 
 install:
 	@mv -v $(TARGET) $(INSTALLPREFIX)/$(TARGET)
 	@chmod 755 $(INSTALLPREFIX)/$(TARGET)
 
 ####### Compile
+
+$(RULESFILE): gen_rules.sh
+	./gen_rules.sh
 
 main.o: main.c
 	$(CC) -c $(CFLAGS) -o main.o main.c

--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,13 @@ LINK          ?= gcc
 LDFLAGS       ?= -m64 -Wl,-O3
 LDLIBS        ?= -lhidapi-libusb
 RM            ?= rm -f
-
+INSTALLPREFIX ?= /usr/local/bin
 
 ####### Files
 
 SOURCES       = main.c
 OBJECTS       = main.o
 TARGET        = apex-macros
-INSTALLPREFIX = /usr/local/bin
-
 
 ####### Build rules
 

--- a/autostart.sh
+++ b/autostart.sh
@@ -1,32 +1,28 @@
 #!/bin/sh
 
-# to enable the autostart, execute this script with
-# this script will create a file '/etc/udev/rules.d/90-apex.rules' to enable the keyboard's macro keys at startup or wakeup
-# further, this script can also undo this by calling it with the '--disable' argument
+# To enable the autostart, execute this script after building this project.
+# It will install the 90-apex.rules file into /etc/udev/rules.d/
+# Further, this script can also undo this by calling it with the '--disable' argument
 
 # the rules file
 file='/etc/udev/rules.d/90-apex.rules'
-
-# the command itself; the wait time can be adjusted if there are some issues with too quick callings
-wait=0.5
-command="/bin/sh -c 'sleep $wait; /usr/local/bin/apex-macros enable'"
 
 if [ $# -eq 0 ]; then
     # activate the autostart
 
     # autostart requires 'apex-macros' to be installed
-    if [ ! -f '/usr/local/bin/apex-macros' ]; then
+    if [ ! -f $(which apex-macros) ]; then
         echo "Apex-Macros is not installed, hence no autostart possible"
         exit 1
+    fi
+    if [ ! -f ./90-apex.rules ]; then
+	echo "rules file not found, did you build the project first with make?"
+	exit 1
     fi
 
     echo "Activating Apex-Macros autostart..."
     sleep 1
-
-    sudo sh -c "echo \"# run Apex-Macros to enable the keyboard's macro keys\" > $file"
-    for idP in 1206 1208 1200 1202; do
-        echo "ACTION==\"add\", ATTRS{idVendor}==\"1038\", ATTRS{idProduct}==\"$idP\", RUN+=\"$command\"" | sudo tee -a $file > /dev/null
-    done
+    sudo cp 90-apex.rules $file
 
     sudo chmod 644 $file
 

--- a/gen_rules.sh
+++ b/gen_rules.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# this script will create a file '90-apex.rules', which can be installed in
+# /etc/udev/rules.d/ to enable the keyboard's macro keys at startup or wakeup
+
+# the command itself; the wait time can be adjusted if there are some issues with too quick callings
+wait=0.5
+if [ -z "$INSTALLPREFIX" ]; then
+    INSTALLPREFIX="/usr/local/bin"
+fi
+command="/bin/sh -c 'sleep $wait; $INSTALLPREFIX/apex-macros enable'"
+file=./90-apex.rules
+
+sh -c "echo \"# run Apex-Macros to enable the keyboard's macro keys\" > $file"
+for idP in 1206 1208 1200 1202; do
+    echo "ACTION==\"add\", ATTRS{idVendor}==\"1038\", ATTRS{idProduct}==\"$idP\", RUN+=\"$command\"" >> $file
+done

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,8 +1,13 @@
 #!/bin/sh
 
-# removes the program by deleting it from /usr/local/bin
-if [ -f '/usr/local/bin/apex-macros' ]; then
-    sudo rm -v '/usr/local/bin/apex-macros'
+if [ -z "$INSTALLPREFIX" ]; then
+    INSTALLPREFIX="/usr/local/bin"
+fi
+
+# removes the program by deleting it from $INSTALLPREFIX (by default
+# from /usr/local/bin)
+if [ -f "$INSTALLPREFIX/apex-macros" ]; then
+    sudo rm -v "$INSTALLPREFIX/apex-macros"
 
     if [ -f '/etc/udev/hwdb.d/90-apex.hwdb' ]; then
         sudo rm -v '/etc/udev/hwdb.d/90-apex.hwdb'


### PR DESCRIPTION
I refactored the `90-apex.rules` file generation logic into its own script, called from the `Makefile` and made the installation location customisable.

I tried to stick to your style & the way how your was already working and minimise the changes.

## Why this proposed change?
This allows me to build an Arch Linux package that includes the udev rules, as during the build process the file needs to go into a different location (from where it can be packaged).

## Impact on users?

I don't think this should impact users in most cases, as they are most likely going to be running `make` before `autostart.sh` already (`autostart.sh` already enforces that `apex-macros` is installed). If you run it without `INSTALLPREFIX` defined it should result in the same installation as before. If you define it consistently, it should all work despite `apex-macros` being installed in a different location. If you run `make` without it being defined and `autorun.sh` with it set to something non-default (or vice versa) then the udev rules may not trigger correctly. I could look into adding some more error handling code to deal with this case if you want.

I hope it works for you and that you find this useful!