### PR TITLE
Added support for SteelSeries HP Omen keyboard

### DIFF
--- a/90-apex.hwdb
+++ b/90-apex.hwdb
@@ -3,7 +3,7 @@
 # 3) sudo udevadm control --reload
 
 #keyboard:usb:v1038p120[02]*
-evdev:input:b0003v1038p120[0268]*
+evdev:input:b0003v1038p120[0268A]*
 # L Keys
  KEYBOARD_KEY_0700a8=prog1
  KEYBOARD_KEY_0700a9=prog2

--- a/gen_rules.sh
+++ b/gen_rules.sh
@@ -12,6 +12,6 @@ command="/bin/sh -c 'sleep $wait; $INSTALLPREFIX/apex-macros enable'"
 file=./90-apex.rules
 
 sh -c "echo \"# run Apex-Macros to enable the keyboard's macro keys\" > $file"
-for idP in 1206 1208 1200 1202 1600; do
+for idP in 1206 120a 1208 1200 1202 1600; do
     echo "ACTION==\"add\", ATTRS{idVendor}==\"1038\", ATTRS{idProduct}==\"$idP\", RUN+=\"$command\"" >> $file
 done

--- a/install.sh
+++ b/install.sh
@@ -55,8 +55,8 @@ if (sudo apex-macros enable); then
     sudo udevadm control --reload
 
     echo "The macro keys were successfully enabled."
-    echo "To manually enable / disable the macro keys, run 'apex-marcros enable' or 'apex-marcros disable', respectively."
-    echo "If you want to enable the autostart, run 'autostart.sh', to uninstall 'apex-marcros' run 'uninstall.sh'."
+    echo "To manually enable / disable the macro keys, run 'apex-macros enable' or 'apex-macros disable', respectively."
+    echo "If you want to enable the autostart, run 'autostart.sh', to uninstall 'apex-macros' run 'uninstall.sh'."
     echo "Thank you for using Apex-Macros and have fun with it! :-)"
 else
     echo "Testing of Apex-Macros failed"

--- a/main.c
+++ b/main.c
@@ -17,15 +17,16 @@ hid_device* find_keyboard()
     hid_device* dev = NULL;
     if (hid_init() == 0)
     {
-        unsigned short ids[5] = {
+        unsigned short ids[6] = {
             0x1206, //Apex 350
+            0x120a, //Apex 350 (SteelSeries HP Omen)
             0x1208, //Apex 300
             0x1200, //Apex
             0x1202, //Apex [RAW]
             0x1600  //Apex M800
         };
 
-        for (int i=0; i<5 && dev == NULL; ++i)
+        for (int i=0; i<6 && dev == NULL; ++i)
             dev = hid_open(0x1038, ids[i], 0);
     }
     return dev;


### PR DESCRIPTION
Hi! I bought HP Omen keyboard by SteelSeries (https://support.hp.com/us-en/product/omen-by-hp-keyboard-with-steelseries/12733358). You can search it also by product code X7Z97AA. It looks like a clone of Apex 350, it is identified as `SteelSeries SteelSeries Apex 350 HP Omen` and `lsusb` says it has code `1038:120a`.

I found your code very useful, however, there is not support for my keyboard. This PR adds `1038:120a` as a supported device. With this patch, everything works as expected for me.

Also, I fixed one typo.